### PR TITLE
[Feature] Pagina detalhes avaliado

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,0 +1,1 @@
+TODO: Listagem de avaliados com link para a página individual

--- a/app/views/participants/show.html.erb
+++ b/app/views/participants/show.html.erb
@@ -1,12 +1,42 @@
+<section>
+  <p>
+    <div><%= Participant.model_name.human %></div>
+      <%= @participant.name %>
+  </p>
+  <p>
+    <div><%= Participant.human_attribute_name(:cpf) %></div>
+      <%= @participant.cpf %>
+  </p>
+  <p>
+    <div><%= Participant.human_attribute_name(:email) %></div>
+      <%= @participant.email %>
+  </p>
+  <p>
+    <div><%= Participant.human_attribute_name(:date_of_birth) %></div>
+      <%= l(@participant.date_of_birth) %>
+  </p>
+</section>
+
+<%= link_to 'Aplicar novo instrumento', new_participant_participant_instrument_path(@participant) %>
+
 <table>
   <tr>
     <th>Nome</th>
+    <th>Descrição</th>
     <th>Status</th>
+    <th>Data de aplicação</th>
+    <th>Data de finalização</th>
+    <th>Pontuação</th>
   </tr>
   <% @participant.participant_instruments.each do |part_inst| %>
     <tr>
       <td><%= part_inst.instrument.name %></td>
+      <td><%= part_inst.instrument.description %></td>
       <td><%= ParticipantInstrument.human_attribute_name("status.#{part_inst.status}") %></td>
+      <td><%= l(part_inst.created_at.to_date) %></td>
+      <%# TODO: create another field for date of conclusion %>
+      <td><%= l(part_inst.updated_at.to_date) if part_inst.finished? %></td>
+      <td><%# TODO: add score here after implementing it %></td>
     </tr>
   <% end %>
 </table>

--- a/app/views/participants/show.html.erb
+++ b/app/views/participants/show.html.erb
@@ -1,42 +1,58 @@
-<section>
-  <p>
-    <div><%= Participant.model_name.human %></div>
-      <%= @participant.name %>
-  </p>
-  <p>
-    <div><%= Participant.human_attribute_name(:cpf) %></div>
-      <%= @participant.cpf %>
-  </p>
-  <p>
-    <div><%= Participant.human_attribute_name(:email) %></div>
-      <%= @participant.email %>
-  </p>
-  <p>
-    <div><%= Participant.human_attribute_name(:date_of_birth) %></div>
-      <%= l(@participant.date_of_birth) %>
-  </p>
+<section class="container w-50 card p-3 mb-5">
+  <div class="row mb-3 justify-content-around">
+    <div class="col">
+      <div class="text-muted"><%= Participant.model_name.human %></div>
+      <div class="fs-5"><%= @participant.name %></div>
+    </div>
+    <div class="col text-end">
+      <div class="text-muted"><%= Participant.human_attribute_name(:cpf) %></div>
+      <div class="fs-5"><%= @participant.cpf %></div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col">
+      <div class="text-muted"><%= Participant.human_attribute_name(:email) %></div>
+      <div class="fs-5"><%= @participant.email %></div>
+    </div>
+    <div class="col text-end">
+      <div class="text-muted"><%= Participant.human_attribute_name(:date_of_birth) %></div>
+      <div class="fs-5"><%= l(@participant.date_of_birth) %></div>
+    </div>
+  </div>
 </section>
 
-<%= link_to 'Aplicar novo instrumento', new_participant_participant_instrument_path(@participant) %>
+<%= link_to 'Aplicar novo instrumento',
+            new_participant_participant_instrument_path(@participant),
+            class: 'btn btn-primary mb-5' %>
 
-<table>
+<h1 class="fs-3 mb-3"><%= t(:assigned_instruments) %></h1>
+<table class="table table-striped">
   <tr>
-    <th>Nome</th>
-    <th>Descrição</th>
-    <th>Status</th>
-    <th>Data de aplicação</th>
-    <th>Data de finalização</th>
-    <th>Pontuação</th>
+    <th><%= Instrument.human_attribute_name(:name) %></th>
+    <th><%= Instrument.human_attribute_name(:description) %></th>
+    <th class="text-end">
+      <%= ParticipantInstrument.human_attribute_name(:status) %>
+    </th>
+    <th class="text-end">
+      <%= ParticipantInstrument.human_attribute_name(:created_at) %>
+    </th>
+    <th class="text-end">
+      <%= ParticipantInstrument.human_attribute_name(:finished_at) %>
+    </th>
+    <th class="text-end">
+      <%= ParticipantInstrument.human_attribute_name(:score) %>
+    </th>
   </tr>
+
   <% @participant.participant_instruments.each do |part_inst| %>
     <tr>
       <td><%= part_inst.instrument.name %></td>
       <td><%= part_inst.instrument.description %></td>
-      <td><%= ParticipantInstrument.human_attribute_name("status.#{part_inst.status}") %></td>
-      <td><%= l(part_inst.created_at.to_date) %></td>
+      <td class="text-end"><%= ParticipantInstrument.human_attribute_name("status.#{part_inst.status}") %></td>
+      <td class="text-end"><%= l(part_inst.created_at.to_date) %></td>
       <%# TODO: create another field for date of conclusion %>
-      <td><%= l(part_inst.updated_at.to_date) if part_inst.finished? %></td>
-      <td><%# TODO: add score here after implementing it %></td>
+      <td class="text-end"><%= l(part_inst.updated_at.to_date) if part_inst.finished? %>TODO</td>
+      <td class="text-end"><%# TODO: add score here after implementing it %>TODO</td>
     </tr>
   <% end %>
 </table>

--- a/config/locales/models/participant_instruments.pt-BR.yml
+++ b/config/locales/models/participant_instruments.pt-BR.yml
@@ -2,6 +2,10 @@ pt-BR:
   activerecord:
     attributes:
       participant_instrument:
+        status: Status
+        score: Pontuação
+        created_at: Data de aplicação 
+        finished_at: Data de finalização
         instrument: Instrumento
         instrument_id: Instrumento
         participant: Avaliado 

--- a/config/locales/models/participants.pt-BR.yml
+++ b/config/locales/models/participants.pt-BR.yml
@@ -15,3 +15,4 @@ pt-BR:
     failure: Não foi possível cadastrar avaliado.
   save: Salvar
   invalid_cpf: inválido
+  assigned_instruments: Instrumentos aplicados

--- a/db/migrate/20240420145902_add_finish_at_to_participant_instruments.rb
+++ b/db/migrate/20240420145902_add_finish_at_to_participant_instruments.rb
@@ -1,0 +1,5 @@
+class AddFinishAtToParticipantInstruments < ActiveRecord::Migration[7.1]
+  def change
+    add_column :participant_instruments, :finished_at, :datetime
+  end
+end

--- a/db/migrate/20240420150130_add_score_to_participant_instruments.rb
+++ b/db/migrate/20240420150130_add_score_to_participant_instruments.rb
@@ -1,0 +1,5 @@
+class AddScoreToParticipantInstruments < ActiveRecord::Migration[7.1]
+  def change
+    add_column :participant_instruments, :score, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_19_224237) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_20_150130) do
   create_table "instruments", force: :cascade do |t|
     t.string "name", null: false
     t.text "description", null: false
@@ -24,6 +24,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_19_224237) do
     t.integer "status", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "finished_at"
+    t.integer "score"
     t.index ["instrument_id"], name: "index_participant_instruments_on_instrument_id"
     t.index ["participant_id"], name: "index_participant_instruments_on_participant_id"
   end

--- a/spec/system/participants/user_assigns_instrument_to_participant_spec.rb
+++ b/spec/system/participants/user_assigns_instrument_to_participant_spec.rb
@@ -8,7 +8,8 @@ describe 'User assigns instrument to participant' do
     create(:instrument, name: 'Teste de Ansiedade',
                         description: 'Avalia possibilidade de quadro ansioso')
 
-    visit new_participant_participant_instrument_path(participant)
+    visit participant_path(participant)
+    click_on 'Aplicar novo instrumento'
     select 'Teste de Ansiedade', from: 'Instrumento'
     click_on 'Aplicar'
 

--- a/spec/system/participants/user_views_participant_details_page_spec.rb
+++ b/spec/system/participants/user_views_participant_details_page_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe 'User views participant page' do
+  it 'and the details are displayed' do
+    participant = create(:participant, name: 'Mara Cristina Pereira', cpf: '414.298.400-48',
+                                       email: 'mara@email.com', date_of_birth: '1989-12-09')
+
+    instrument_one = create(:instrument, name: 'Teste de Depressão',
+                                         description: 'Avalia probalidade de depressão')
+    instrument_two = create(:instrument, name: 'Teste de Ansiedade Geral',
+                                         description: 'Avalia possibilidade de quadro ansioso')
+
+    participant.participant_instruments.create!(instrument: instrument_one, status: :pending,
+                                                created_at: '2022-01-29')
+    participant.participant_instruments.create!(instrument: instrument_two, status: :finished,
+                                                created_at: '2021-03-14', updated_at: '2021-03-17')
+
+    # TODO: visit root path after creating participants list on the home page
+    visit participant_path(participant)
+
+    expect(page).to have_content 'Mara Cristina Pereira'
+    expect(page).to have_content '414.298.400-48'
+    expect(page).to have_content 'mara@email.com'
+    expect(page).to have_content '09/12/1989'
+    expect(page).to have_link 'Aplicar novo instrumento'
+
+    within 'table tr:first-child' do
+      expect(page).to have_selector 'th:nth-of-type(1)', text: 'Nome'
+      expect(page).to have_selector 'th:nth-of-type(2)', text: 'Descrição'
+      expect(page).to have_selector 'th:nth-of-type(3)', text: 'Status'
+      expect(page).to have_selector 'th:nth-of-type(4)', text: 'Data de aplicação'
+      expect(page).to have_selector 'th:nth-of-type(5)', text: 'Data de finalização'
+      expect(page).to have_selector 'th:nth-of-type(6)', text: 'Pontuação'
+    end
+
+    within 'table tr:nth-child(2)' do
+      expect(page).to have_selector 'td:nth-of-type(1)', text: 'Teste de Depressão'
+      expect(page).to have_selector 'td:nth-of-type(2)', text: 'Avalia probalidade de depressão'
+      expect(page).to have_selector 'td:nth-of-type(3)', text: 'Pendente'
+      expect(page).to have_selector 'td:nth-of-type(4)', text: '29/01/2022'
+      expect(page).to have_selector 'td:nth-of-type(5)', text: ''
+      # TODO: update score here after implementing it in other issue
+      expect(page).to have_selector 'td:nth-of-type(6)', text: ''
+    end
+
+    within 'table tr:nth-child(3)' do
+      expect(page).to have_selector 'td:nth-of-type(1)', text: 'Teste de Ansiedade Geral'
+      expect(page).to have_selector 'td:nth-of-type(2)', text: 'Avalia possibilidade de quadro ansioso'
+      expect(page).to have_selector 'td:nth-of-type(3)', text: 'Finalizado'
+      expect(page).to have_selector 'td:nth-of-type(4)', text: '14/03/2021'
+      expect(page).to have_selector 'td:nth-of-type(5)', text: '17/03/2021'
+      expect(page).to have_selector 'td:nth-of-type(6)', text: ''
+    end
+  end
+end


### PR DESCRIPTION
Esse PR resolve a issue #3 

Autenticado como psicólogo eu necessito acessar a página de um avaliado e listar os instrumentos que foram aplicados nesse avaliado.

- [x] Criar tabela na página do avaliado listando os instrumentos aplicados
- [x] A tabela de instrumentos deve ter as colunas nome, descrição, data em que foi aplicado, data em que foi finalizado, status e pontuação (que ficará vazia por enquanto pois será tratado em nova issue).
- [x] A página deve ter as informações do avaliado: nome, cpf, email e data de nascimento

![image](https://github.com/paulohenrique-gh/rails-vetor/assets/124916478/0a7dc168-5791-416a-88af-b41222d075a2)

## Débitos:
- Ajustar alguns testes de sistemas para serem iniciados no `root_path` após listagem de avaliados ser implementada na home
- Atualizar pontuação e data de finalização na tabela de instrumentos aplicados em um avaliado, depois que for implementada a funcionalidade de responder ao questionário