### PR TITLE
[Feature] Envio de link ao email do avaliado

### DIFF
--- a/app/controllers/participant_instruments_controller.rb
+++ b/app/controllers/participant_instruments_controller.rb
@@ -15,7 +15,7 @@ class ParticipantInstrumentsController < ApplicationController
     participant_instrument = ParticipantInstrument.new(participant:, instrument:)
 
     participant_instrument.save
-    ParticipantInstrumentMailer.with(participant_instrument:).notify_participant.deliver_later
+    ParticipantInstrumentMailer.with(participant_instrument:).notify_participant.deliver_now
 
     redirect_to participant, notice: t('.success')
   end

--- a/app/controllers/participant_instruments_controller.rb
+++ b/app/controllers/participant_instruments_controller.rb
@@ -1,4 +1,8 @@
 class ParticipantInstrumentsController < ApplicationController
+  def show
+    @participant_instrument = ParticipantInstrument.find(params[:participant_instrument_id])
+  end
+
   def new
     @participant = Participant.find(params[:participant_id])
     @participant_instrument = @participant.participant_instruments.build
@@ -10,6 +14,9 @@ class ParticipantInstrumentsController < ApplicationController
     instrument = Instrument.find(params[:participant_instrument][:instrument_id])
     participant_instrument = ParticipantInstrument.new(participant:, instrument:)
 
-    redirect_to participant, notice: t('.success') if participant_instrument.save
+    participant_instrument.save
+    ParticipantInstrumentMailer.with(participant_instrument:).notify_participant.deliver_later
+
+    redirect_to participant, notice: t('.success')
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'questionarios@desafiovetor.com.br'
   layout 'mailer'
 end

--- a/app/mailers/participant_instrument_mailer.rb
+++ b/app/mailers/participant_instrument_mailer.rb
@@ -1,0 +1,8 @@
+class ParticipantInstrumentMailer < ApplicationMailer
+  def notify_participant
+    @participant = params[:participant_instrument].participant
+    @instrument = params[:participant_instrument].instrument
+    
+    mail(subject: 'Novo Questionário', to: @participant.email)
+  end
+end

--- a/app/mailers/participant_instrument_mailer.rb
+++ b/app/mailers/participant_instrument_mailer.rb
@@ -2,7 +2,9 @@ class ParticipantInstrumentMailer < ApplicationMailer
   def notify_participant
     @participant = params[:participant_instrument].participant
     @instrument = params[:participant_instrument].instrument
-    
-    mail(subject: 'Novo Questionário', to: @participant.email)
+    @participant_instrument_id = params[:participant_instrument].id
+    @link = "http://localhost:3000/participant_instruments/#{(@participant_instrument_id)}"
+
+    mail(subject: 'Vetor - Novo Questionário', to: @participant.email)
   end
 end

--- a/app/views/participant_instrument_mailer/notify_participant.html.erb
+++ b/app/views/participant_instrument_mailer/notify_participant.html.erb
@@ -2,4 +2,6 @@
 <br />
 <p style="font-size: 20px">Você tem um novo questionário pendente.</p>
 <br />
-<p style="font-size: 20px">Clique <a href="http://localhost:3000/instruments/12313">aqui</a> para acessar.</p>
+<p style="font-size: 20px">
+  Clique <a href="<%= @link %>">aqui</a> para acessar.
+</p>

--- a/app/views/participant_instrument_mailer/notify_participant.html.erb
+++ b/app/views/participant_instrument_mailer/notify_participant.html.erb
@@ -1,0 +1,5 @@
+<h1>Olá, <strong><%= @participant.name %></strong></h1>
+<br />
+<p style="font-size: 20px">Você tem um novo questionário pendente.</p>
+<br />
+<p style="font-size: 20px">Clique <a href="http://localhost:3000/instruments/12313">aqui</a> para acessar.</p>

--- a/app/views/participant_instruments/show.html.erb
+++ b/app/views/participant_instruments/show.html.erb
@@ -1,0 +1,1 @@
+<%= @participant_instrument.participant.name %>

--- a/app/views/participant_instruments/show.html.erb
+++ b/app/views/participant_instruments/show.html.erb
@@ -1,1 +1,3 @@
 <%= @participant_instrument.participant.name %>
+Placeholder
+<%# TODO: fill the page with questions from the instrument %>

--- a/app/views/participants/_participant.html.erb
+++ b/app/views/participants/_participant.html.erb
@@ -1,0 +1,22 @@
+<section class="container w-50 card p-3 mb-5">
+  <div class="row mb-3 justify-content-around">
+    <div class="col">
+      <div class="text-muted"><%= Participant.model_name.human %></div>
+      <div class="fs-5"><%= participant.name %></div>
+    </div>
+    <div class="col text-end">
+      <div class="text-muted"><%= Participant.human_attribute_name(:cpf) %></div>
+      <div class="fs-5"><%= participant.cpf %></div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col">
+      <div class="text-muted"><%= Participant.human_attribute_name(:email) %></div>
+      <div class="fs-5"><%= participant.email %></div>
+    </div>
+    <div class="col text-end">
+      <div class="text-muted"><%= Participant.human_attribute_name(:date_of_birth) %></div>
+      <div class="fs-5"><%= l(participant.date_of_birth) %></div>
+    </div>
+  </div>
+</section>

--- a/app/views/participants/_participant_instruments_table.html.erb
+++ b/app/views/participants/_participant_instruments_table.html.erb
@@ -1,0 +1,30 @@
+<h1 class="fs-3 mb-3"><%= t(:assigned_instruments) %></h1>
+<table class="table table-striped">
+  <tr>
+    <th><%= Instrument.human_attribute_name(:name) %></th>
+    <th><%= Instrument.human_attribute_name(:description) %></th>
+    <th class="text-end">
+      <%= ParticipantInstrument.human_attribute_name(:status) %>
+    </th>
+    <th class="text-end">
+      <%= ParticipantInstrument.human_attribute_name(:created_at) %>
+    </th>
+    <th class="text-end">
+      <%= ParticipantInstrument.human_attribute_name(:finished_at) %>
+    </th>
+    <th class="text-end">
+      <%= ParticipantInstrument.human_attribute_name(:score) %>
+    </th>
+  </tr>
+
+  <% participant_instruments.each do |part_inst| %>
+    <tr>
+      <td><%= part_inst.instrument.name %></td>
+      <td><%= part_inst.instrument.description %></td>
+      <td class="text-end"><%= ParticipantInstrument.human_attribute_name("status.#{part_inst.status}") %></td>
+      <td class="text-end"><%= l(part_inst.created_at.to_date) %></td>
+      <td class="text-end"><%= l(part_inst.finished_at&.to_date) if part_inst.finished? %></td>
+      <td class="text-end"><%# TODO: add score here after implementing it %></td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/participants/show.html.erb
+++ b/app/views/participants/show.html.erb
@@ -1,3 +1,4 @@
+<%# TODO: create partials for each section %>
 <section class="container w-50 card p-3 mb-5">
   <div class="row mb-3 justify-content-around">
     <div class="col">
@@ -21,6 +22,7 @@
   </div>
 </section>
 
+<%# FIXME: use I18n %>
 <%= link_to 'Aplicar novo instrumento',
             new_participant_participant_instrument_path(@participant),
             class: 'btn btn-primary mb-5' %>

--- a/app/views/participants/show.html.erb
+++ b/app/views/participants/show.html.erb
@@ -1,60 +1,8 @@
-<%# TODO: create partials for each section %>
-<section class="container w-50 card p-3 mb-5">
-  <div class="row mb-3 justify-content-around">
-    <div class="col">
-      <div class="text-muted"><%= Participant.model_name.human %></div>
-      <div class="fs-5"><%= @participant.name %></div>
-    </div>
-    <div class="col text-end">
-      <div class="text-muted"><%= Participant.human_attribute_name(:cpf) %></div>
-      <div class="fs-5"><%= @participant.cpf %></div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col">
-      <div class="text-muted"><%= Participant.human_attribute_name(:email) %></div>
-      <div class="fs-5"><%= @participant.email %></div>
-    </div>
-    <div class="col text-end">
-      <div class="text-muted"><%= Participant.human_attribute_name(:date_of_birth) %></div>
-      <div class="fs-5"><%= l(@participant.date_of_birth) %></div>
-    </div>
-  </div>
-</section>
+<%= render @participant %>
 
-<%# FIXME: use I18n %>
-<%= link_to 'Aplicar novo instrumento',
+<%= link_to t(:assign_new),
             new_participant_participant_instrument_path(@participant),
             class: 'btn btn-primary mb-5' %>
 
-<h1 class="fs-3 mb-3"><%= t(:assigned_instruments) %></h1>
-<table class="table table-striped">
-  <tr>
-    <th><%= Instrument.human_attribute_name(:name) %></th>
-    <th><%= Instrument.human_attribute_name(:description) %></th>
-    <th class="text-end">
-      <%= ParticipantInstrument.human_attribute_name(:status) %>
-    </th>
-    <th class="text-end">
-      <%= ParticipantInstrument.human_attribute_name(:created_at) %>
-    </th>
-    <th class="text-end">
-      <%= ParticipantInstrument.human_attribute_name(:finished_at) %>
-    </th>
-    <th class="text-end">
-      <%= ParticipantInstrument.human_attribute_name(:score) %>
-    </th>
-  </tr>
-
-  <% @participant.participant_instruments.each do |part_inst| %>
-    <tr>
-      <td><%= part_inst.instrument.name %></td>
-      <td><%= part_inst.instrument.description %></td>
-      <td class="text-end"><%= ParticipantInstrument.human_attribute_name("status.#{part_inst.status}") %></td>
-      <td class="text-end"><%= l(part_inst.created_at.to_date) %></td>
-      <%# TODO: create another field for date of conclusion %>
-      <td class="text-end"><%= l(part_inst.updated_at.to_date) if part_inst.finished? %>TODO</td>
-      <td class="text-end"><%# TODO: add score here after implementing it %>TODO</td>
-    </tr>
-  <% end %>
-</table>
+<%= render partial: 'participant_instruments_table',
+           locals: { participant_instruments: @participant.participant_instruments } %>

--- a/config/locales/models/participant_instruments.pt-BR.yml
+++ b/config/locales/models/participant_instruments.pt-BR.yml
@@ -16,5 +16,6 @@ pt-BR:
   participant_instruments:
     success: Instrumento aplicado com sucesso!
     failure: Não foi possível aplicar instrumento.
+  assign_new: Aplicar novo instrumento
   assign: Aplicar
   select_prompt: Selecione um instrumento

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,11 @@
 Rails.application.routes.draw do
-  root to: 'home#index' 
+  root to: 'home#index'
 
   resources :participants, only: %i[show new create] do
     resources :participant_instruments, only: %i[new create]
   end
+
+  get 'participant_instruments/:participant_instrument_id',
+      to: 'participant_instruments#show',
+      as: :participant_instruments
 end

--- a/spec/mailers/participant_instrument_mailer_spec.rb
+++ b/spec/mailers/participant_instrument_mailer_spec.rb
@@ -10,12 +10,15 @@ RSpec.describe ParticipantInstrumentMailer, type: :mailer do
 
       mail = ParticipantInstrumentMailer.with(participant_instrument:).notify_participant
 
-      expect(mail.subject).to eq 'Novo Questionário'
+      expect(mail.subject).to eq 'Vetor - Novo Questionário'
       expect(mail.to.size).to eq 1
       expect(mail.to).to include participant.email
       expect(mail.body).to include 'Olá, <strong>Carlos Eduardo Batista</strong>'
       expect(mail.body).to include 'Você tem um novo questionário pendente.'
-      expect(mail.body).to include 'Clique <a href="http://localhost:3000/instruments/12313">aqui</a> para acessar.'
+      link = "http://localhost:3000#{participant_instruments_path(participant_instrument)}"
+      expect(mail.body).to include(
+        "Clique <a href=\"#{link}\">aqui</a> para acessar."
+      )
     end
   end
 end

--- a/spec/mailers/participant_instrument_mailer_spec.rb
+++ b/spec/mailers/participant_instrument_mailer_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe ParticipantInstrumentMailer, type: :mailer do
+  context '#notify_participant' do
+    it 'sends email with link to instrument' do
+      participant = create(:participant, name: 'Carlos Eduardo Batista',
+                                         email: 'eduardo@email.com')
+      instrument = create(:instrument)
+      participant_instrument = participant.participant_instruments.create!(instrument:)
+
+      mail = ParticipantInstrumentMailer.with(participant_instrument:).notify_participant
+
+      expect(mail.subject).to eq 'Novo Questionário'
+      expect(mail.to.size).to eq 1
+      expect(mail.to).to include participant.email
+      expect(mail.body).to include 'Olá, <strong>Carlos Eduardo Batista</strong>'
+      expect(mail.body).to include 'Você tem um novo questionário pendente.'
+      expect(mail.body).to include 'Clique <a href="http://localhost:3000/instruments/12313">aqui</a> para acessar.'
+    end
+  end
+end

--- a/spec/mailers/previews/participant_instrument_mailer_preview.rb
+++ b/spec/mailers/previews/participant_instrument_mailer_preview.rb
@@ -1,0 +1,7 @@
+class ParticipantInstrumentMailerPreview < ActionMailer::Preview
+  def notify_participant
+    participant_instrument = ParticipantInstrument.pending.last
+
+    ParticipantInstrumentMailer.with(participant_instrument:).notify_participant
+  end
+end

--- a/spec/system/participants/user_assigns_instrument_to_participant_spec.rb
+++ b/spec/system/participants/user_assigns_instrument_to_participant_spec.rb
@@ -19,7 +19,7 @@ describe 'User assigns instrument to participant' do
       expect(page).to have_content 'Teste de Ansiedade'
       expect(page).to have_content 'Pendente'
     end
-    email = ActionMailer::Base.deliveries.find { |mail| mail.to.include?(participant.email)}
-    expect(email.to).to eq participant.email
+    email = ActionMailer::Base.deliveries.find { |mail| mail.to.include?(participant.email) }
+    expect(email.to).to include participant.email
   end
 end

--- a/spec/system/participants/user_assigns_instrument_to_participant_spec.rb
+++ b/spec/system/participants/user_assigns_instrument_to_participant_spec.rb
@@ -19,5 +19,7 @@ describe 'User assigns instrument to participant' do
       expect(page).to have_content 'Teste de Ansiedade'
       expect(page).to have_content 'Pendente'
     end
+    email = ActionMailer::Base.deliveries.find { |mail| mail.to.include?(participant.email)}
+    expect(email.to).to eq participant.email
   end
 end

--- a/spec/system/participants/user_views_participant_details_page_spec.rb
+++ b/spec/system/participants/user_views_participant_details_page_spec.rb
@@ -13,7 +13,7 @@ describe 'User views participant page' do
     participant.participant_instruments.create!(instrument: instrument_one, status: :pending,
                                                 created_at: '2022-01-29')
     participant.participant_instruments.create!(instrument: instrument_two, status: :finished,
-                                                created_at: '2021-03-14', updated_at: '2021-03-17')
+                                                created_at: '2021-03-14', finished_at: '2021-03-17')
 
     # TODO: visit root path after creating participants list on the home page
     visit participant_path(participant)


### PR DESCRIPTION
Esse PR resolve a issue #7 

Autenticado como um psicólogo, ao distribuir um instrumento, deve ser enviado um e-mail para o avaliado com o link para que o instrumento seja executado.

- [x] Criar página para o instrumento (placeholder até implementação do questionário)
- [x] Criar mailer para envio do link da página ao email do avaliado
- [x] Incluir envio do email na action que cria o objeto `participant_instrument`

![image](https://github.com/paulohenrique-gh/rails-vetor/assets/124916478/1361308b-44ee-4ee1-8ba0-4a42bae9a4bd)
