### PR TITLE
[Feature] Redireciona avaliado para validação antes de carregar instrumento

### DIFF
--- a/app/controllers/participant_instruments_controller.rb
+++ b/app/controllers/participant_instruments_controller.rb
@@ -2,7 +2,7 @@ class ParticipantInstrumentsController < ApplicationController
   def show
     unless session[:participant_validated]
       return redirect_to participant_instrument_validation_path(params[:id]),
-             alert: t('.participant_not_validated')
+                         alert: t('.participant_not_validated')
     end
 
     @participant_instrument = ParticipantInstrument.find(params[:id])
@@ -25,20 +25,29 @@ class ParticipantInstrumentsController < ApplicationController
     redirect_to participant, notice: t('.success')
   end
 
-  def validation    
+  def validation
     @participant = Participant.new
   end
 
   def validate_participant
-    submitted_data = params.require(:participant).permit(:name, :cpf, :email, :date_of_birth)
     participant = ParticipantInstrument.find(params[:participant_instrument_id]).participant
 
-    if participant.valid_data?(submitted_data)
-      session[:participant_validated] = true
+    if participant.valid_data?(submitted_participant_data)
+      store_validation
       return redirect_to participant_instrument_path(params[:participant_instrument_id])
     end
 
     flash.now[:alert] = t('.incorrect_data')
     render :validation, status: :unauthorized
+  end
+
+  private
+
+  def submitted_participant_data
+    params.require(:participant).permit(:name, :cpf, :email, :date_of_birth)
+  end
+
+  def store_validation
+    session[:participant_validated] = true
   end
 end

--- a/app/controllers/participant_instruments_controller.rb
+++ b/app/controllers/participant_instruments_controller.rb
@@ -1,6 +1,11 @@
 class ParticipantInstrumentsController < ApplicationController
   def show
-    @participant_instrument = ParticipantInstrument.find(params[:participant_instrument_id])
+    unless session[:participant_validated]
+      return redirect_to participant_instrument_validation_path(params[:id]),
+             alert: t('.participant_not_validated')
+    end
+
+    @participant_instrument = ParticipantInstrument.find(params[:id])
   end
 
   def new
@@ -18,5 +23,22 @@ class ParticipantInstrumentsController < ApplicationController
     ParticipantInstrumentMailer.with(participant_instrument:).notify_participant.deliver_now
 
     redirect_to participant, notice: t('.success')
+  end
+
+  def validation    
+    @participant = Participant.new
+  end
+
+  def validate_participant
+    submitted_data = params.require(:participant).permit(:name, :cpf, :email, :date_of_birth)
+    participant = ParticipantInstrument.find(params[:participant_instrument_id]).participant
+
+    if participant.valid_data?(submitted_data)
+      session[:participant_validated] = true
+      return redirect_to participant_instrument_path(params[:participant_instrument_id])
+    end
+
+    flash.now[:alert] = t('.incorrect_data')
+    render :validation, status: :unauthorized
   end
 end

--- a/app/mailers/participant_instrument_mailer.rb
+++ b/app/mailers/participant_instrument_mailer.rb
@@ -3,7 +3,7 @@ class ParticipantInstrumentMailer < ApplicationMailer
     @participant = params[:participant_instrument].participant
     @instrument = params[:participant_instrument].instrument
     @participant_instrument_id = params[:participant_instrument].id
-    @link = "http://localhost:3000/participant_instruments/#{@participant_instrument_id}"
+    @link = "http://localhost:3000/participant_instruments/#{@participant_instrument_id}/validation"
 
     mail(subject: t(:mail_subject), to: @participant.email)
   end

--- a/app/mailers/participant_instrument_mailer.rb
+++ b/app/mailers/participant_instrument_mailer.rb
@@ -3,8 +3,8 @@ class ParticipantInstrumentMailer < ApplicationMailer
     @participant = params[:participant_instrument].participant
     @instrument = params[:participant_instrument].instrument
     @participant_instrument_id = params[:participant_instrument].id
-    @link = "http://localhost:3000/participant_instruments/#{(@participant_instrument_id)}"
+    @link = "http://localhost:3000/participant_instruments/#{@participant_instrument_id}"
 
-    mail(subject: 'Vetor - Novo Questionário', to: @participant.email)
+    mail(subject: t(:mail_subject), to: @participant.email)
   end
 end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -8,6 +8,15 @@ class Participant < ApplicationRecord
 
   validate :validate_cpf
 
+  def valid_data?(data)
+    symbolized_data = data.to_h.symbolize_keys
+
+    name.downcase == symbolized_data[:name].downcase &&
+    cpf.gsub(/[^\d]/, '') == symbolized_data[:cpf].gsub(/[^\d]/, '') &&
+    email.downcase == symbolized_data[:email].downcase &&
+    date_of_birth.to_date == symbolized_data[:date_of_birth].to_date
+  end
+
   private
 
   def validate_cpf

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -11,15 +11,31 @@ class Participant < ApplicationRecord
   def valid_data?(data)
     symbolized_data = data.to_h.symbolize_keys
 
-    name.downcase == symbolized_data[:name].downcase &&
-    cpf.gsub(/[^\d]/, '') == symbolized_data[:cpf].gsub(/[^\d]/, '') &&
-    email.downcase == symbolized_data[:email].downcase &&
-    date_of_birth.to_date == symbolized_data[:date_of_birth].to_date
+    same_name?(symbolized_data[:name]) &&
+      same_cpf?(symbolized_data[:cpf]) &&
+      same_email?(symbolized_data[:email]) &&
+      same_date_of_birth?(symbolized_data[:date_of_birth])
   end
 
   private
 
   def validate_cpf
     errors.add(:cpf, I18n.t(:invalid_cpf)) unless cpf.blank? || CPF.valid?(cpf)
+  end
+
+  def same_name?(name_to_compare)
+    name.downcase == name_to_compare.downcase
+  end
+
+  def same_cpf?(cpf_to_compare)
+    cpf.gsub(/[^\d]/, '') == cpf_to_compare.gsub(/[^\d]/, '')
+  end
+
+  def same_email?(email_to_compare)
+    email.downcase == email_to_compare.downcase
+  end
+
+  def same_date_of_birth?(date_of_birth_to_compare)
+    date_of_birth.to_date == date_of_birth_to_compare.to_date
   end
 end

--- a/app/views/participant_instruments/validation.html.erb
+++ b/app/views/participant_instruments/validation.html.erb
@@ -1,0 +1,38 @@
+<%= form_with(model: @participant,
+              url: participant_instrument_validate_participant_path,
+              class: 'w-25') do |f| %>
+  <div class="d-flex flex-column mb-3">
+    <%= f.label :name, class: 'form-label' %>
+    <%= f.text_field :name,
+      required: true,
+      placeholder: 'ex.: José Maria dos Santos',
+      class: 'form-control' %>
+  </div>
+
+  <div class="d-flex flex-column mb-3">
+    <%= f.label :cpf, class: 'form-label' %>
+    <%= f.text_field :cpf,
+      required: true,
+      placeholder: 'ex.: 01234567890',
+      class: 'form-control' %>
+  </div>
+
+  <div class="d-flex flex-column mb-3">
+    <%= f.label :email, class: 'form-label' %>
+    <%= f.email_field :email,
+      required: true,
+      placeholder: 'ex.: exemplo@email.com',
+      class: 'form-control' %>
+  </div>
+
+  <div class="d-flex flex-column mb-3">
+    <%= f.label :date_of_birth, class: 'form-label' %>
+    <%= f.date_field :date_of_birth,
+      required: true,
+      class: 'form-control' %>
+  </div>
+
+  <div class="text-center">
+    <%= f.submit t(:confirm), class: 'btn btn-primary' %>
+  </div>
+<% end %>

--- a/app/views/participant_instruments/validation.html.erb
+++ b/app/views/participant_instruments/validation.html.erb
@@ -1,3 +1,5 @@
+<div class="alert alert-warning">Valide os dados antes de prosseguir para o questionário</div>
+
 <%= form_with(model: @participant,
               url: participant_instrument_validate_participant_path,
               class: 'w-25') do |f| %>

--- a/config/locales/models/participant_instruments.pt-BR.yml
+++ b/config/locales/models/participant_instruments.pt-BR.yml
@@ -19,3 +19,4 @@ pt-BR:
   assign_new: Aplicar novo instrumento
   assign: Aplicar
   select_prompt: Selecione um instrumento
+  mail_subject: Vetor - Novo Questionário

--- a/config/locales/models/participant_instruments.pt-BR.yml
+++ b/config/locales/models/participant_instruments.pt-BR.yml
@@ -16,7 +16,11 @@ pt-BR:
   participant_instruments:
     success: Instrumento aplicado com sucesso!
     failure: Não foi possível aplicar instrumento.
+    participant_not_validated: Dados não validados
+    incorrect_data: Dados incorretos
   assign_new: Aplicar novo instrumento
   assign: Aplicar
+  confirm: Confirmar
   select_prompt: Selecione um instrumento
   mail_subject: Vetor - Novo Questionário
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,16 @@
 Rails.application.routes.draw do
   root to: 'home#index'
 
-  resources :participants, only: %i[show new create] do
-    resources :participant_instruments, only: %i[new create]
+  resources :participants, only: %i[show new create], shallow: true do
+    resources :participant_instruments, only: %i[show new create] do
+      get 'validation', to: 'participant_instruments#validation'
+      post 'validate_participant', to: 'participant_instruments#validate_participant'
+    end
   end
 
-  get 'participant_instruments/:participant_instrument_id',
-      to: 'participant_instruments#show',
-      as: :participant_instruments
+  # get 'participant_instruments/:participant_instrument_id', to: 'participant_instruments#show',
+  #                                                           as: :participant_instruments do
+  #   get 'validate_participant',
+  #       to: 'participant_instruments#validate_participant'
+  # end
 end

--- a/spec/factories/participant_instruments.rb
+++ b/spec/factories/participant_instruments.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :participant_instrument do
     participant { nil }
     instrument { nil }
-    status { 1 }
+    status { 0 }
   end
 end

--- a/spec/mailers/participant_instrument_mailer_spec.rb
+++ b/spec/mailers/participant_instrument_mailer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ParticipantInstrumentMailer, type: :mailer do
       expect(mail.to).to include participant.email
       expect(mail.body).to include 'Olá, <strong>Carlos Eduardo Batista</strong>'
       expect(mail.body).to include 'Você tem um novo questionário pendente.'
-      link = "http://localhost:3000#{participant_instruments_path(participant_instrument)}"
+      link = "http://localhost:3000#{participant_instrument_path(participant_instrument)}"
       expect(mail.body).to include(
         "Clique <a href=\"#{link}\">aqui</a> para acessar."
       )

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -68,4 +68,28 @@ RSpec.describe Participant, type: :model do
       expect(participant.errors).to be_empty
     end
   end
+
+  context '#valid_data?' do
+    it 'returns false when data submitted is invalid' do
+      invalid_data = { name: 'Carlos Barbosa', cpf: '00099988877',
+                       email: 'carlos@email.com', date_of_birth: '20/11/1989' }
+      participant = build(:participant, name: 'Luiz Daniel', cpf: '59551881001',
+                                        email: 'luiz@email.com', date_of_birth: '14/04/2001')
+
+      result = participant.valid_data?(invalid_data)
+
+      expect(result).to be false
+    end
+
+    it 'returns true when data is the valid' do
+      valid_data = { name: 'LUIZ DANIEL', cpf: '595.518.810-01',
+                     email: 'luiz@email.com', date_of_birth: '14/04/2001' }
+      participant = build(:participant, name: 'Luiz Daniel', cpf: '59551881001',
+                                        email: 'luiz@email.com', date_of_birth: '14/04/2001')
+
+      result = participant.valid_data?(valid_data)
+
+      expect(result).to be true
+    end
+  end
 end

--- a/spec/system/instruments/participant_views_instrument_page_spec.rb
+++ b/spec/system/instruments/participant_views_instrument_page_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe 'Participant accesses instrument link' do
+  it 'and is redirected to survey after successful validation' do
+    participant = create(:participant, name: 'Carlos Andrade', email: 'carlos@email.com',
+                                       cpf: '176.814.070-73', date_of_birth: '1987-12-06')
+    instrument = create(:instrument)
+    participant_instrument = participant.participant_instruments.create!(instrument:)
+
+    visit participant_instrument_validation_path(participant_instrument)
+
+    fill_in 'Nome', with: 'Carlos Andrade'
+    fill_in 'CPF', with: '176.814.070-73'
+    fill_in 'E-mail', with: 'carlos@email.com'
+    fill_in 'Data de nascimento', with: '06/12/1987'
+    click_on 'Confirmar'
+
+    expect(current_path).to eq participant_instrument_path(participant_instrument)
+  end
+
+  it 'and is not redirected if validation fails' do
+    participant = create(:participant, name: 'Carlos Andrade', email: 'carlos@email.com',
+                                       cpf: '176.814.070-73', date_of_birth: '1987-12-06')
+    instrument = create(:instrument)
+    participant_instrument = participant.participant_instruments.create!(instrument:)
+
+    visit participant_instrument_validation_path(participant_instrument)
+
+    fill_in 'Nome', with: 'Vitor Barbosa'
+    fill_in 'CPF', with: '182.809.073-97'
+    fill_in 'E-mail', with: 'vitor@email.com'
+    fill_in 'Data de nascimento', with: '10/07/1992'
+    click_on 'Confirmar'
+
+    expect(page).to have_content 'Dados incorretos'
+    expect(current_path).not_to eq participant_instrument_path(participant_instrument)
+  end
+
+  it 'and is redirected to validation when they skip it' do
+    participant = create(:participant)
+    instrument = create(:instrument)
+    participant_instrument = participant.participant_instruments.create!(instrument:)
+
+    visit participant_instrument_path(participant_instrument)
+
+    expect(page).to have_content 'Dados não validados'
+    expect(current_path).to eq participant_instrument_validation_path(participant_instrument)
+  end
+end


### PR DESCRIPTION
Esse PR resolve  #9 

Como um avaliado eu devo clicar no link recebido via email e ser redirecionado para o sistema.

- [x] Criar formulário para preenchimento dos dados do avaliado.
- [x] Validar os dados do formulário. Caso sejam equivalentes aos dados do avaliado, direcionar para a página do instrumento

![image](https://github.com/paulohenrique-gh/rails-vetor/assets/124916478/09404910-3688-4f06-8e7a-6e6747e9da3f)

## Como é feita a validação?
- Avaliado acessa o link no email e é direcionado para validação. A página carrega um formulário para confirmação dos dados.
- A action `ParticipantInstrumentsController#validate_participant` chama um método `store_validation` para armazenar um valor booleano na sessão, indicando que o avaliado foi validado com sucesso
- Avaliado é então direcionado para a página com o questionário (ainda não implementada)
- Caso haja tentativa de acesso direto à página do questionário sem a validação salva na sessão, avaliado é direcionado de volta para a página de validação