### PR TITLE
Incluir dados iniciais para a aplicação nos seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,24 @@ Foi utilizado o dbdocs para documentar o schema do banco de dados nos links abai
 
 ## Funcionalidades
 
+A aplicação inicia com dados pré-cadastrados. Você pode testar as funcionalidades utilizando os dados abaixo: 
+Psicólogo:
+    - E-mail: user@email.com
+    - Senha: password
+Esse usuário já possui 3 avaliados cadastrados, cada um com um instrumento finalizado e outro pendente.
+
+Se quiser cadastrar outro avaliado, pode usar os dados fictícios abaixo:
+Novo avaliado:
+    - Nome: Sasha Levy
+    - CPF: 30902403001
+    - E-mail: waravor@mailinator.com
+    - Data de nascimento: 13/05/1975
+
+Link para visualização do e-mail enviado ao atribuir instrumento: http://localhost:3000/rails/mailers/participant_instrument_mailer/notify_participant 
+
 ### Autenticação
 
 O psicólogo se cadastra na plataforma informando e-mail e senha.
-
-Foi utilizada a gem [cpf_cnpj](https://github.com/fnando/cpf_cnpj) para ajudar na validação e permitir somente CPF válido. Para gerar CPF fictício válido, recomenda-se o site https://www.4devs.com.br/gerador_de_cpf.
 
 Depois disso, o psicólogo consegue fazer o login e utilizar o restante das funcionalidades
 
@@ -77,7 +90,9 @@ Depois disso, o psicólogo consegue fazer o login e utilizar o restante das func
 
 Rota: `participants/new`
 
-O psicólogo autenticado consegue cadastrar avaliado informando nome, cpf, e-mail e data de nascimento, a partir de link na página inicial ou na navbar
+O psicólogo autenticado consegue cadastrar avaliado informando nome, cpf, e-mail e data de nascimento, a partir de link na página inicial ou na navbar.
+
+Foi utilizada a gem [cpf_cnpj](https://github.com/fnando/cpf_cnpj) para ajudar na validação e permitir somente CPF válido. Para gerar CPF fictício válido, recomenda-se o site https://www.4devs.com.br/gerador_de_cpf.
 
 ![image](https://github.com/paulohenrique-gh/rails-vetor/assets/124916478/f1f382f6-d33e-4ecd-a2e0-7ff9c973f2bb)
 
@@ -110,7 +125,7 @@ A aplicação foi configurada para carregar uma prévia do e-mail enviado para o
 
 Rota da validação: `participant_instruments/:participant_instrument_id/validation`
 
-Ao clicar no link recebido, o avaliado é direcionado para a página de validação se os dados ainda não tiverem sido preenchidos. Se os dados já tiverem sido confirmados, o avaliado é direcionado para a página com as questões do instrumento.
+Ao clicar no link recebido, o avaliado é direcionado para a página de validação se os dados ainda não tiverem sido preenchidos. Após preenchimento dos dados, o avaliado é direcionado para a página com as questões do instrumento.
 
 ![image](https://github.com/paulohenrique-gh/rails-vetor/assets/124916478/14fe412d-fb52-409b-877c-0ac1dd0b2205)
 
@@ -128,7 +143,7 @@ O resultado do instrumento fica disponível somente para o psicólogo.
 
 Rota da página de resultados: `participant_instruments/:participant_instrument_id/results`
 
-A partir do link "Detalhes" correspondente a de instrumento da página de um avaliado, o psicólogo autenticado tem acesso à página com os resultados do instrumento.
+A partir do link "Detalhes" correspondente a um instrumento na página de um avaliado, o psicólogo autenticado tem acesso à página com os resultados do instrumento.
 A página tem um resumo das informações do instrumento, a pontuação total, as questões do instrumento e as respostas do avaliado.
 
 ![image](https://github.com/paulohenrique-gh/rails-vetor/assets/124916478/8d9b297f-2926-465d-85eb-eab01e622ebb)

--- a/README.md
+++ b/README.md
@@ -64,13 +64,18 @@ Foi utilizado o dbdocs para documentar o schema do banco de dados nos links abai
 ## Funcionalidades
 
 A aplicação inicia com dados pré-cadastrados. Você pode testar as funcionalidades utilizando os dados abaixo: 
+
 Psicólogo:
+
     - E-mail: user@email.com
     - Senha: password
+
 Esse usuário já possui 3 avaliados cadastrados, cada um com um instrumento finalizado e outro pendente.
 
 Se quiser cadastrar outro avaliado, pode usar os dados fictícios abaixo:
+
 Novo avaliado:
+
     - Nome: Sasha Levy
     - CPF: 30902403001
     - E-mail: waravor@mailinator.com

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -11,7 +11,7 @@ class AnswersController < ApplicationController
       return render 'instruments/load_questionnaire', status: :bad_request
     end
 
-    Answer.save_answers(answers: answers_params, participant_instrument: @participant_instrument)
+    Answer.save_answers(options: options_from_params, participant_instrument: @participant_instrument)
     clear_session
 
     redirect_to instrument_completion_path
@@ -25,6 +25,10 @@ class AnswersController < ApplicationController
 
   def answers_params
     params[:answers].permit(QUESTION_INDEXES.map { |index| { index => [:option_id] } })
+  end
+
+  def options_from_params
+    Option.find(answers_params.values.map { |a| a[:option_id] })
   end
 
   def clear_session

--- a/app/controllers/instruments_controller.rb
+++ b/app/controllers/instruments_controller.rb
@@ -3,6 +3,7 @@ class InstrumentsController < ApplicationController
 
   def load_questionnaire
     unless participant_validated?
+      # TODO: remove flash massage?
       return redirect_to participant_instrument_validation_path(params[:participant_instrument_id]),
                          alert: t('.participant_not_validated')
     end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -6,11 +6,15 @@ class Answer < ApplicationRecord
 
   delegate :weight, to: :option
 
-  def self.save_answers(answers:, participant_instrument:)
-    answers.each_value do |answer|
-      option = Option.find(answer[:option_id])
+  def self.save_answers(options:, participant_instrument:)
+    options.each do |option|
       create!(option:, participant_instrument:)
     end
+
+    # answers.each_value do |answer|
+    #   option = Option.find(answer[:option_id])
+    #   create!(option:, participant_instrument:)
+    # end
 
     participant_instrument.compute_score
   end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -11,11 +11,6 @@ class Answer < ApplicationRecord
       create!(option:, participant_instrument:)
     end
 
-    # answers.each_value do |answer|
-    #   option = Option.find(answer[:option_id])
-    #   create!(option:, participant_instrument:)
-    # end
-
     participant_instrument.compute_score
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,3 +1,4 @@
+<%# TODO: remove button style %>
 <%= link_to t(:register_new_participant), new_participant_path, class: 'btn btn-primary mb-5' %>
 
 <% if @participants.any? %>

--- a/app/views/participants/_participant_instruments_table.html.erb
+++ b/app/views/participants/_participant_instruments_table.html.erb
@@ -22,7 +22,7 @@
       <td><%= part_inst.instrument.name %></td>
       <td class="text-end"><%= ParticipantInstrument.human_attribute_name("status.#{part_inst.status}") %></td>
       <td class="text-end"><%= l(part_inst.created_at.to_date) %></td>
-      <td class="text-end"><%= l(part_inst.finished_at.to_date) if part_inst.finished? %></td>
+      <td class="text-end"><%= l(part_inst.finished_at.to_date) if part_inst.finished? && part_inst.finished_at %></td>
       <td class="text-end"><%= part_inst.score %></td>
       <td class="text-end"><%= link_to 'Detalhes', participant_instrument_results_path(part_inst) %></td>
     </tr>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -270,3 +270,20 @@ rescue StandardError => e
   Instrument.destroy_all if Instrument.any?
   puts "Aborted: #{e}"
 end
+
+psychologist = Psychologist.create!(email: 'user@email.com', password: 'password')
+participant1 = Participant.create!(name: 'João Carlos Batista', cpf: '13650579090',
+                                   email: 'jcbatista@email.com', date_of_birth: '1980-12-01', psychologist:)
+participant2 = Participant.create!(name: 'Milena Alves', cpf: '81196899096',
+                                   email: 'milena@email.com', date_of_birth: '1993-04-25', psychologist:)
+participant3 = Participant.create!(name: 'Sheila Rita das Neves', cpf: '77487199002',
+                                   email: 'sheila@email.com', date_of_birth: '1999-07-13', psychologist:)
+
+psychologist.participants.each do |participant|
+  random_instrument = Instrument.all.sample
+  participant_instrument = participant.participant_instruments.create!(instrument: random_instrument,
+                                                                       status: :finished)
+  participant_instrument.questions.each do |question|
+    participant_instrument.answers.create!(option: question.options.sample)
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -290,17 +290,18 @@ begin
   instrument_hashes = [depression, anxiety, emotional_intelligence, empathy, stress_level]
 
   instrument_hashes.each { |i| create_questionnaire(i[:instrument], i[:questions_and_options]) }
+
+  psychologist = Psychologist.create!(email: 'user@email.com', password: 'password')
+  psychologist.participants.create!(name: 'João Carlos Batista', cpf: '13650579090',
+                                    email: 'jcbatista@email.com', date_of_birth: '1980-12-01')
+  psychologist.participants.create!(name: 'Milena Alves', cpf: '81196899096',
+                                    email: 'milena@email.com', date_of_birth: '1993-04-25')
+  psychologist.participants.create!(name: 'Sheila Rita das Neves', cpf: '77487199002',
+                                    email: 'sheila@email.com', date_of_birth: '1999-07-13')
+
+  psychologist.participants.each { |participant| assign_instruments(participant) }
 rescue StandardError => e
   Instrument.destroy_all if Instrument.any?
+  Psychologist.destroy_all if Psychologist.any?
   puts "Aborted: #{e}"
 end
-
-psychologist = Psychologist.create!(email: 'user@email.com', password: 'password')
-participant1 = Participant.create!(name: 'João Carlos Batista', cpf: '13650579090',
-                                   email: 'jcbatista@email.com', date_of_birth: '1980-12-01', psychologist:)
-participant2 = Participant.create!(name: 'Milena Alves', cpf: '81196899096',
-                                   email: 'milena@email.com', date_of_birth: '1993-04-25', psychologist:)
-participant3 = Participant.create!(name: 'Sheila Rita das Neves', cpf: '77487199002',
-                                   email: 'sheila@email.com', date_of_birth: '1999-07-13', psychologist:)
-
-psychologist.participants.each { |participant| assign_instruments(participant) }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -281,9 +281,13 @@ participant3 = Participant.create!(name: 'Sheila Rita das Neves', cpf: '77487199
 
 psychologist.participants.each do |participant|
   random_instrument = Instrument.all.sample
-  participant_instrument = participant.participant_instruments.create!(instrument: random_instrument,
-                                                                       status: :finished)
-  participant_instrument.questions.each do |question|
+  participant_instrument = participant
+                           .participant_instruments
+                           .create!(instrument: random_instrument,
+                                    status: :finished, finished_at: Time.zone.now)
+  answers = participant_instrument.questions.map do |question|
     participant_instrument.answers.create!(option: question.options.sample)
   end
+
+  Answer.save_answers(answers:, participant_instrument:)
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,160 +7,266 @@ def create_questionnaire(instrument, questions_and_options)
   end
 end
 
-depression = { instrument: Instrument.create!(name: 'Teste de Depressão',
-                                              description: 'Avalia probalidade de depressão') }
-anxiety = { instrument: Instrument.create!(name: 'Teste de Ansiedade Geral',
-                                           description: 'Avalia possibilidade de quadro ansioso') }
-emotional_intelligence = { instrument: Instrument.create!(name: 'Inteligência Emocional',
-                                                          description: 'Avalia capacidade de reconhecer, interpretar e lidar com emoções') }
+begin
+  depression = { instrument: Instrument.create!(name: 'Teste de Depressão',
+                                                description: 'Avalia probalidade de depressão') }
+  depression_questions_and_options = [
+    {
+      question: 'Como você tem se sentido?',
+      options: [
+        { description: 'Muito triste', weight: 3 },
+        { description: 'Triste', weight: 2 },
+        { description: 'Neutro', weight: 1 },
+        { description: 'Feliz', weight: 0 }
+      ]
+    },
+    {
+      question: 'Você sente que perdeu interesse nas coisas em geral',
+      options: [
+        { description: 'Muito', weight: 3 },
+        { description: 'Moderadamente', weight: 2 },
+        { description: 'Não muito', weight: 1 },
+        { description: 'Não', weight: 0 }
+      ]
+    },
+    {
+      question: 'Você tem tido dificuldade para dormir?',
+      options: [
+        { description: 'Sim, muita', weight: 3 },
+        { description: 'Um pouco', weight: 2 },
+        { description: 'Raramente', weight: 1 },
+        { description: 'Não', weight: 0 }
+      ]
+    },
+    {
+      question: 'Você tem tido pensamentos negativos',
+      options: [
+        { description: 'Sim, muitos', weight: 3 },
+        { description: 'Um pouco', weight: 2 },
+        { description: 'Raramente', weight: 1 },
+        { description: 'Não', weight: 0 }
+      ]
+    },
+    {
+      question: 'Você tem se sentido sem energia?',
+      options: [
+        { description: 'Sim, demais', weight: 3 },
+        { description: 'Um pouco', weight: 2 },
+        { description: 'Levemente', weight: 1 },
+        { description: 'Não', weight: 0 }
+      ]
+    }
+  ]
+  depression[:questions_and_options] = depression_questions_and_options
 
-depression_questions_and_options = [
-  {
-    question: 'Como você tem se sentido?',
-    options: [
-      { description: 'Muito triste', weight: 3 },
-      { description: 'Triste', weight: 2 },
-      { description: 'Neutro', weight: 1 },
-      { description: 'Feliz', weight: 0 }
-    ]
-  },
-  {
-    question: 'Você sente que perdeu interesse nas coisas em geral',
-    options: [
-      { description: 'Muito', weight: 3 },
-      { description: 'Moderadamente', weight: 2 },
-      { description: 'Não muito', weight: 1 },
-      { description: 'Não', weight: 0 }
-    ]
-  },
-  {
-    question: 'Você tem tido dificuldade para dormir?',
-    options: [
-      { description: 'Sim, muita', weight: 3 },
-      { description: 'Um pouco', weight: 2 },
-      { description: 'Raramente', weight: 1 },
-      { description: 'Não', weight: 0 }
-    ]
-  },
-  {
-    question: 'Você tem tido pensamentos negativos',
-    options: [
-      { description: 'Sim, muitos', weight: 3 },
-      { description: 'Um pouco', weight: 2 },
-      { description: 'Raramente', weight: 1 },
-      { description: 'Não', weight: 0 }
-    ]
-  },
-  {
-    question: 'Você tem se sentido sem energia?',
-    options: [
-      { description: 'Sim, demais', weight: 3 },
-      { description: 'Um pouco', weight: 2 },
-      { description: 'Levemente', weight: 1 },
-      { description: 'Não', weight: 0 }
-    ]
-  }
-]
-depression[:questions_and_options] = depression_questions_and_options
+  anxiety = { instrument: Instrument.create!(name: 'Teste de Ansiedade Geral',
+                                             description: 'Avalia possibilidade de quadro ansioso') }
+  anxiety_questions_and_options = [
+    {
+      question: 'Você tem tido dificuldades para relaxar?',
+      options: [
+        { description: 'Sim, muita', weight: 3 },
+        { description: 'Não muita', weight: 2 },
+        { description: 'Levemente', weight: 1 },
+        { description: 'Não', weight: 0 }
+      ]
+    },
+    {
+      question: 'Você tem sentido medo de que algo ruim aconteça?',
+      options: [
+        { description: 'Sim, demais', weight: 3 },
+        { description: 'Moderadamente', weight: 2 },
+        { description: 'Não muito', weight: 1 },
+        { description: 'Não', weight: 0 }
+      ]
+    },
+    {
+      question: 'Você tem sentido tontura?',
+      options: [
+        { description: 'Sim, muita', weight: 3 },
+        { description: 'Um pouco', weight: 2 },
+        { description: 'Raramente', weight: 1 },
+        { description: 'Não', weight: 0 }
+      ]
+    },
+    {
+      question: 'Na última semana você ficou nervoso(a)?',
+      options: [
+        { description: 'Sim, frequentemente', weight: 3 },
+        { description: 'Algumas vezes', weight: 2 },
+        { description: 'Raramente', weight: 1 },
+        { description: 'Não', weight: 0 }
+      ]
+    },
+    {
+      question: 'Você tem tido dificuldades para respirar?',
+      options: [
+        { description: 'Sim, demais', weight: 3 },
+        { description: 'Um pouco', weight: 2 },
+        { description: 'Levemente', weight: 1 },
+        { description: 'Não', weight: 0 }
+      ]
+    }
+  ]
+  anxiety[:questions_and_options] = anxiety_questions_and_options
 
-anxiety_questions_and_options = [
-  {
-    question: 'Você tem tido dificuldades para relaxar?',
-    options: [
-      { description: 'Sim, muita', weight: 3 },
-      { description: 'Não muita', weight: 2 },
-      { description: 'Levemente', weight: 1 },
-      { description: 'Não', weight: 0 }
-    ]
-  },
-  {
-    question: 'Você tem sentido medo de que algo ruim aconteça?',
-    options: [
-      { description: 'Sim, demais', weight: 3 },
-      { description: 'Moderadamente', weight: 2 },
-      { description: 'Não muito', weight: 1 },
-      { description: 'Não', weight: 0 }
-    ]
-  },
-  {
-    question: 'Você tem sentido tontura?',
-    options: [
-      { description: 'Sim, muita', weight: 3 },
-      { description: 'Um pouco', weight: 2 },
-      { description: 'Raramente', weight: 1 },
-      { description: 'Não', weight: 0 }
-    ]
-  },
-  {
-    question: 'Na última semana você ficou nervoso(a)?',
-    options: [
-      { description: 'Sim, frequentemente', weight: 3 },
-      { description: 'Algumas vezes', weight: 2 },
-      { description: 'Raramente', weight: 1 },
-      { description: 'Não', weight: 0 }
-    ]
-  },
-  {
-    question: 'Você tem tido dificuldades para respirar?',
-    options: [
-      { description: 'Sim, demais', weight: 3 },
-      { description: 'Um pouco', weight: 2 },
-      { description: 'Levemente', weight: 1 },
-      { description: 'Não', weight: 0 }
-    ]
-  }
-]
-anxiety[:questions_and_options] = anxiety_questions_and_options
+  emotional_intelligence = { instrument: Instrument.create!(name: 'Inteligência Emocional',
+                                                            description: 'Avalia capacidade de reconhecer, interpretar e lidar com emoções') }
+  emotional_intelligence_questions_and_options = [
+    {
+      question: 'Você sabe identificar as emoções que sente?',
+      options: [
+        { description: 'Sempre', weight: 3 },
+        { description: 'Frequentemente', weight: 2 },
+        { description: 'Raramente', weight: 1 },
+        { description: 'Nunca', weight: 0 }
+      ]
+    },
+    {
+      question: 'Você sabe se acalmar quando se sente inquieto ou chateado?',
+      options: [
+        { description: 'Sempre', weight: 3 },
+        { description: 'Frequentemente', weight: 2 },
+        { description: 'Raramente', weight: 1 },
+        { description: 'Nunca', weight: 0 }
+      ]
+    },
+    {
+      question: 'Você define metas a longo prazo?',
+      options: [
+        { description: 'Sempre', weight: 3 },
+        { description: 'Frequentemente', weight: 2 },
+        { description: 'Raramente', weight: 1 },
+        { description: 'Nunca', weight: 0 }
+      ]
+    },
+    {
+      question: 'Você é um bom ouvinte?',
+      options: [
+        { description: 'Sempre', weight: 3 },
+        { description: 'Frequentemente', weight: 2 },
+        { description: 'Raramente', weight: 1 },
+        { description: 'Nunca', weight: 0 }
+      ]
+    },
+    {
+      question: 'Você reconhece como seu comportamento afeta os outros?',
+      options: [
+        { description: 'Sempre', weight: 3 },
+        { description: 'Frequentemente', weight: 2 },
+        { description: 'Raramente', weight: 1 },
+        { description: 'Nunca', weight: 0 }
+      ]
+    }
+  ]
+  emotional_intelligence[:questions_and_options] = emotional_intelligence_questions_and_options
 
-emotional_intelligence_questions_and_options = [
-  {
-    question: 'Você sabe identificar as emoções que sente?',
-    options: [
-      { description: 'Sempre', weight: 3 },
-      { description: 'Frequentemente', weight: 2 },
-      { description: 'Raramente', weight: 1 },
-      { description: 'Nunca', weight: 0 }
-    ]
-  },
-  {
-    question: 'Você sabe se acalmar quando se sente inquieto ou chateado?',
-    options: [
-      { description: 'Sempre', weight: 3 },
-      { description: 'Frequentemente', weight: 2 },
-      { description: 'Raramente', weight: 1 },
-      { description: 'Nunca', weight: 0 }
-    ]
-  },
-  {
-    question: 'Você define metas a longo prazo?',
-    options: [
-      { description: 'Sempre', weight: 3 },
-      { description: 'Frequentemente', weight: 2 },
-      { description: 'Raramente', weight: 1 },
-      { description: 'Nunca', weight: 0 }
-    ]
-  },
-  {
-    question: 'Você é um bom ouvinte?',
-    options: [
-      { description: 'Sempre', weight: 3 },
-      { description: 'Frequentemente', weight: 2 },
-      { description: 'Raramente', weight: 1 },
-      { description: 'Nunca', weight: 0 }
-    ]
-  },
-  {
-    question: 'Você reconhece como seu comportamento afeta os outros?',
-    options: [
-      { description: 'Sempre', weight: 3 },
-      { description: 'Frequentemente', weight: 2 },
-      { description: 'Raramente', weight: 1 },
-      { description: 'Nunca', weight: 0 }
-    ]
-  }
-]
-emotional_intelligence[:questions_and_options] = emotional_intelligence_questions_and_options
+  empathy = { instrument: Instrument.create!(name: 'Teste de Empatia',
+                                             description: 'Avalia níveis de empatia do avaliado') }
+  empathy_questions_and_options = [
+    {
+      question: 'Você tem dificuldade para entender as emoções dos outros?',
+      options: [
+        { description: 'Sim, muita', weight: 3 },
+        { description: 'Um pouco', weight: 2 },
+        { description: 'Raramente', weight: 1 },
+        { description: 'Não', weight: 0 }
+      ]
+    },
+    {
+      question: 'Você acha divertido intimidar as pessoas de vez em quando?',
+      options: [
+        { description: 'Sim, demais', weight: 3 },
+        { description: 'Um pouco', weight: 2 },
+        { description: 'Raramente', weight: 1 },
+        { description: 'Não', weight: 0 }
+      ]
+    },
+    {
+      question: 'Você percebe quando alguém está com medo?',
+      options: [
+        { description: 'Sim, sempre', weight: 3 },
+        { description: 'Um pouco', weight: 2 },
+        { description: 'Raramente', weight: 1 },
+        { description: 'Não', weight: 0 }
+      ]
+    },
+    {
+      question: 'É óbvio para você quando as pessoas fingem que estão felizes?',
+      options: [
+        { description: 'Sim, sempre', weight: 3 },
+        { description: 'Um pouco', weight: 2 },
+        { description: 'Raramente', weight: 1 },
+        { description: 'Não', weight: 0 }
+      ]
+    },
+    {
+      question: 'Você gosta de ver as pessoas ficarem com raiva?',
+      options: [
+        { description: 'Sim, demais', weight: 3 },
+        { description: 'Um pouco', weight: 2 },
+        { description: 'Raramente', weight: 1 },
+        { description: 'Não', weight: 0 }
+      ]
+    }
+  ]
+  empathy[:questions_and_options] = empathy_questions_and_options
 
-instruments_hash = [depression, anxiety, emotional_intelligence]
+  stress_level = { instrument: Instrument.create!(name: 'Grau de Estresse',
+                                                  description: 'Avalia grau de estresse do avaliado') }
+  stress_level_questions_and_options = [
+    {
+      question: 'Com qual frequência você tem olhado para o relógio sem necessidade?',
+      options: [
+        { description: 'Muitas vezes', weight: 3 },
+        { description: 'Algumas vezes', weight: 2 },
+        { description: 'Poucas vezes', weight: 1 },
+        { description: 'Nunca', weight: 0 }
+      ]
+    },
+    {
+      question: 'Você tem se sentido mais tenso nas suas atividades cotidianas?',
+      options: [
+        { description: 'Sim, demais', weight: 3 },
+        { description: 'Um pouco', weight: 2 },
+        { description: 'Raramente', weight: 1 },
+        { description: 'Não', weight: 0 }
+      ]
+    },
+    {
+      question: 'Você tem perdido o controle emocional quando se sente frustrado?',
+      options: [
+        { description: 'Sim, demais', weight: 3 },
+        { description: 'Um pouco', weight: 2 },
+        { description: 'Raramente', weight: 1 },
+        { description: 'Não', weight: 0 }
+      ]
+    },
+    {
+      question: 'Você sente angústia ou inquietação quanto fica sem fazer nada?',
+      options: [
+        { description: 'Sim, sempre', weight: 3 },
+        { description: 'Um pouco', weight: 2 },
+        { description: 'Raramente', weight: 1 },
+        { description: 'Não', weight: 0 }
+      ]
+    },
+    {
+      question: 'Você se sente sobrecarregado pelas responsabilidades do cotidiano?',
+      options: [
+        { description: 'Sim, demais', weight: 3 },
+        { description: 'Um pouco', weight: 2 },
+        { description: 'Raramente', weight: 1 },
+        { description: 'Não', weight: 0 }
+      ]
+    }
+  ]
+  stress_level[:questions_and_options] = stress_level_questions_and_options
 
-instruments_hash.each { |i| create_questionnaire(i[:instrument], i[:questions_and_options]) }
+  instrument_hashes = [depression, anxiety, emotional_intelligence, empathy, stress_level]
+
+  instrument_hashes.each { |i| create_questionnaire(i[:instrument], i[:questions_and_options]) }
+rescue StandardError => e
+  Instrument.destroy_all if Instrument.any?
+  puts "Aborted: #{e}"
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,12 +7,12 @@ def create_questionnaire(instrument, questions_and_options)
   end
 end
 
-depression = Instrument.create!(name: 'Teste de Depressão',
-                                description: 'Avalia probalidade de depressão')
-anxiety = Instrument.create!(name: 'Teste de Ansiedade Geral',
-                             description: 'Avalia possibilidade de quadro ansioso')
-emotional_intelligence = Instrument.create!(name: 'Inteligência Emocional',
-                                            description: 'Avalia capacidade de reconhecer, interpretar e lidar com emoções')
+depression = { instrument: Instrument.create!(name: 'Teste de Depressão',
+                                              description: 'Avalia probalidade de depressão') }
+anxiety = { instrument: Instrument.create!(name: 'Teste de Ansiedade Geral',
+                                           description: 'Avalia possibilidade de quadro ansioso') }
+emotional_intelligence = { instrument: Instrument.create!(name: 'Inteligência Emocional',
+                                                          description: 'Avalia capacidade de reconhecer, interpretar e lidar com emoções') }
 
 depression_questions_and_options = [
   {
@@ -61,6 +61,7 @@ depression_questions_and_options = [
     ]
   }
 ]
+depression[:questions_and_options] = depression_questions_and_options
 
 anxiety_questions_and_options = [
   {
@@ -109,6 +110,7 @@ anxiety_questions_and_options = [
     ]
   }
 ]
+anxiety[:questions_and_options] = anxiety_questions_and_options
 
 emotional_intelligence_questions_and_options = [
   {
@@ -157,7 +159,8 @@ emotional_intelligence_questions_and_options = [
     ]
   }
 ]
+emotional_intelligence[:questions_and_options] = emotional_intelligence_questions_and_options
 
-create_questionnaire(depression, depression_questions_and_options)
-create_questionnaire(anxiety, anxiety_questions_and_options)
-create_questionnaire(emotional_intelligence, emotional_intelligence_questions_and_options)
+instruments_hash = [depression, anxiety, emotional_intelligence]
+
+instruments_hash.each { |i| create_questionnaire(i[:instrument], i[:questions_and_options]) }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,6 +7,30 @@ def create_questionnaire(instrument, questions_and_options)
   end
 end
 
+def random_instrument
+  Instrument.all.sample
+end
+
+def assign_new_instrument(participant)
+  participant.participant_instruments.create!(instrument: random_instrument)
+end
+
+def generate_selected_options(assigned_instrument)
+  assigned_instrument.questions.map { |question| question.options.sample }
+end
+
+def answer_questions(assigned_instrument)
+  selected_options = generate_selected_options(assigned_instrument)
+  Answer.save_answers(options: selected_options, participant_instrument: assigned_instrument)
+end
+
+def assign_instruments(participant)
+  finished_instrument = assign_new_instrument(participant)
+  answer_questions(finished_instrument)
+
+  assign_new_instrument(participant)
+end
+
 begin
   depression = { instrument: Instrument.create!(name: 'Teste de Depressão',
                                                 description: 'Avalia probalidade de depressão') }
@@ -279,15 +303,4 @@ participant2 = Participant.create!(name: 'Milena Alves', cpf: '81196899096',
 participant3 = Participant.create!(name: 'Sheila Rita das Neves', cpf: '77487199002',
                                    email: 'sheila@email.com', date_of_birth: '1999-07-13', psychologist:)
 
-psychologist.participants.each do |participant|
-  random_instrument = Instrument.all.sample
-  participant_instrument = participant
-                           .participant_instruments
-                           .create!(instrument: random_instrument,
-                                    status: :finished, finished_at: Time.zone.now)
-  answers = participant_instrument.questions.map do |question|
-    participant_instrument.answers.create!(option: question.options.sample)
-  end
-
-  Answer.save_answers(answers:, participant_instrument:)
-end
+psychologist.participants.each { |participant| assign_instruments(participant) }

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -18,15 +18,15 @@ RSpec.describe Answer, type: :model do
       selected_option_for_question4 = create(:option, question: question4, weight: 1)
       selected_option_for_question5 = create(:option, question: question5, weight: 3)
 
-      answers_params = {
-        question1: { option_id: selected_option_for_question1.id },
-        question2: { option_id: selected_option_for_question2.id },
-        question3: { option_id: selected_option_for_question3.id },
-        question4: { option_id: selected_option_for_question4.id },
-        question5: { option_id: selected_option_for_question5.id }
-      }
+      selected_options = [
+        selected_option_for_question1,
+        selected_option_for_question2,
+        selected_option_for_question3,
+        selected_option_for_question4,
+        selected_option_for_question5
+      ]
 
-      Answer.save_answers(answers: answers_params, participant_instrument:)
+      Answer.save_answers(options: selected_options, participant_instrument:)
 
       expect(participant_instrument.answers.count).to eq 5
     end

--- a/spec/system/instruments/participant_validates_info_spec.rb
+++ b/spec/system/instruments/participant_validates_info_spec.rb
@@ -43,6 +43,7 @@ describe 'Participant accesses instrument link' do
 
     visit participant_instrument_questionnaire_path(participant_instrument)
 
+    # TODO: remove this after removing flash message
     expect(page).to have_content 'Dados não validados'
     expect(current_path).to eq participant_instrument_validation_path(participant_instrument)
   end


### PR DESCRIPTION
Esse PR resolve a issue #24 

- [x] Atualizar o seeds com mais instrumentos, pelo menos um psicólogo, alguns avaliados e alguns instrumentos já aplicados pendentes e finalizados.
- [x] Atualizar o README incluindo dados para testar a aplicação como dados do login de um psicólogo, e dados para cadastrar novo avaliado.